### PR TITLE
Add CREATE opcode and finalize account, block and contract interfaces

### DIFF
--- a/lib/evm.ex
+++ b/lib/evm.ex
@@ -11,10 +11,16 @@ defmodule EVM do
   @type timestamp :: integer()
 
   @max_int round(:math.pow(2, 256))
+  @max_address round(:math.pow(2, 160))
 
   @doc """
   Returns maximum allowed integer size.
   """
   def max_int(), do: @max_int
+
+  @doc """
+  Returns the maximum allowed address size.
+  """
+  def max_address, do: @max_address
 
 end

--- a/lib/evm/exec_env.ex
+++ b/lib/evm/exec_env.ex
@@ -20,7 +20,7 @@ defmodule EVM.ExecEnv do
     value_in_wei: nil,           # v
     machine_code: <<>>,          # b
     stack_depth: nil,            # e
-    block_interface: nil,        # h (TODO: Check on this)
+    block_interface: nil,        # h (wrapped in interface)
     account_interface: nil,
     contract_interface: nil,
   ]

--- a/lib/evm/exec_env.ex
+++ b/lib/evm/exec_env.ex
@@ -4,6 +4,9 @@ defmodule EVM.ExecEnv do
   to this EVM being called. This is, for instance, the sender of
   a payment or message to a contract, or a sub-contract call.
 
+  We've added our interfaces for interacting with contracts
+  and accounts to this struct as well.
+
   This generally relates to `I` in the Yellow Paper, defined in
   Section 9.3.
   """
@@ -16,8 +19,11 @@ defmodule EVM.ExecEnv do
     sender: nil,                 # s
     value_in_wei: nil,           # v
     machine_code: <<>>,          # b
-    block_header: nil,           # h
-    stack_depth: nil]            # e
+    stack_depth: nil,            # e
+    block_interface: nil,        # h (TODO: Check on this)
+    account_interface: nil,
+    contract_interface: nil,
+  ]
 
   @type t :: %__MODULE__{
     address: EVM.address,
@@ -27,8 +33,10 @@ defmodule EVM.ExecEnv do
     sender: EVM.address,
     value_in_wei: EVM.Wei.t,
     machine_code: EVM.MachineCode.t,
-    block_header: binary(),
-    stack_depth: integer()
+    stack_depth: integer(),
+    block_interface: EVM.Interface.BlockInterface.t,
+    account_interface: EVM.Interface.AccountInterface.t,
+    contract_interface: EVM.Interface.ContractInterface.t,
   }
 
   @doc """
@@ -40,8 +48,8 @@ defmodule EVM.ExecEnv do
 
   # TODO: Examples
   """
-  @spec exec_env_for_message_call(EVM.address, EVM.address, EVM.Gas.gas_price, binary(), EVM.address, EVM.Wei.t, integer(), binary(), EVM.MachineCode.t) :: t
-  def exec_env_for_message_call(recipient, originator, gas_price, data, sender, value_in_wei, stack_depth, block_header, machine_code) do
+  @spec exec_env_for_message_call(EVM.address, EVM.address, EVM.Gas.gas_price, binary(), EVM.address, EVM.Wei.t, integer(), EVM.MachineCode.t, EVM.Interface.BlockInterface.t, EVM.Interface.AccountInterface.t, EVM.Interface.ContractInterface.t) :: t
+  def exec_env_for_message_call(recipient, originator, gas_price, data, sender, value_in_wei, stack_depth, machine_code, block_interface, account_interface, contract_interface) do
     %__MODULE__{
       address: recipient,
       originator: originator,
@@ -50,8 +58,10 @@ defmodule EVM.ExecEnv do
       sender: sender,
       value_in_wei: value_in_wei,
       stack_depth: stack_depth,
-      block_header: block_header,
       machine_code: machine_code,
+      block_interface: block_interface,
+      account_interface: account_interface,
+      contract_interface: contract_interface,
     }
   end
 

--- a/lib/evm/interface/account_interface.ex
+++ b/lib/evm/interface/account_interface.ex
@@ -8,4 +8,7 @@ defprotocol EVM.Interface.AccountInterface do
   @spec get_account_balance(t, EVM.state, EVM.address) :: nil | EVM.Wei.t
   def get_account_balance(t, state, address)
 
+  @spec increment_account_nonce(t, EVM.state, EVM.address) :: { EVM.state, integer() }
+  def increment_account_nonce(t, state, address)
+
 end

--- a/lib/evm/interface/contract_interface.ex
+++ b/lib/evm/interface/contract_interface.ex
@@ -8,4 +8,10 @@ defprotocol EVM.Interface.ContractInterface do
   @spec message_call(t, EVM.state, EVM.address, EVM.address, EVM.address, EVM.address, EVM.Gas.t, EVM.Gas.gas_price, EVM.Wei.t, EVM.Wei.t, binary(), integer(), Header.t) :: { EVM.state, EVM.Gas.t, EVM.SubState.t, EVM.VM.output }
   def message_call(t, state, sender, originator, recipient, contract, available_gas, gas_price, value, apparent_value, data, stack_depth, block_header)
 
+  @spec create_contract(t, EVM.state, EVM.address, EVM.address, EVM.Gas.t, EVM.Gas.gas_price, EVM.Wei.t, EVM.MachineCode.t, integer(), Header.t) :: { EVM.state, EVM.Gas.t, EVM.SubState.t }
+  def create_contract(t, state, sender, originator, available_gas, gas_price, endowment, init_code, stack_depth, block_header)
+
+  @spec new_contract_address(t, EVM.address, integer()) :: EVM.address
+  def new_contract_address(t, address, nonce)
+
 end

--- a/lib/evm/interface/mock/mock_account_interface.ex
+++ b/lib/evm/interface/mock/mock_account_interface.ex
@@ -4,7 +4,8 @@ defmodule EVM.Interface.Mock.MockAccountInterface do
   """
 
   defstruct [
-    balance: nil
+    balance: nil,
+    nonce: nil
   ]
 
   def new(opts) do
@@ -18,6 +19,11 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
   @spec get_account_balance(EVM.Interface.AccountInterface.t, EVM.state, EVM.address) :: nil | EVM.Wei.t
   def get_account_balance(mock_account_interface, _state, _address) do
     mock_account_interface.balance
+  end
+
+  @spec increment_account_nonce(EVM.Interface.AccountInterface.t, EVM.state, EVM.address) :: { EVM.state, integer() }
+  def increment_account_nonce(mock_account_interface, state, _address) do
+    { state, mock_account_interface.nonce + 1 }
   end
 
 end

--- a/lib/evm/interface/mock/mock_contract_interface.ex
+++ b/lib/evm/interface/mock/mock_contract_interface.ex
@@ -33,4 +33,18 @@ defimpl EVM.Interface.ContractInterface, for: EVM.Interface.Mock.MockContractInt
     }
   end
 
+  @spec create_contract(EVM.Interface.ContractInterface.t, EVM.state, EVM.address, EVM.address, EVM.Gas.t, EVM.Gas.gas_price, EVM.Wei.t, EVM.MachineCode.t, integer(), Header.t) :: { EVM.state, EVM.Gas.t, EVM.SubState.t }
+  def create_contract(mock_contract_interface, state, sender, originator, available_gas, gas_price, endowment, init_code, stack_depth, block_header) do
+    {
+      mock_contract_interface.state,
+      mock_contract_interface.gas,
+      mock_contract_interface.sub_state
+    }
+  end
+
+  @spec new_contract_address(EVM.Interface.ContractInterface.t, EVM.address, integer()) :: EVM.address
+  def new_contract_address(_mock_contract_interface, address, _nonce) do
+    address
+  end
+
 end

--- a/lib/evm/operation/block_information.ex
+++ b/lib/evm/operation/block_information.ex
@@ -14,23 +14,24 @@ defmodule EVM.Operation.BlockInformation do
       iex> genesis_block = %Block.Header{number: 0, parent_hash: <<0x00::256>>}
       iex> block_map = %{"gen_block" => genesis_block, "block_a" => block_a, "block_b" => block_b}
       iex> block_interface = EVM.Interface.Mock.MockBlockInterface.new(block_b, block_map)
-      iex> EVM.Operation.BlockInformation.blockhash([3], %{block_interface: block_interface})
+      iex> exec_env = %EVM.ExecEnv{block_interface: block_interface}
+      iex> EVM.Operation.BlockInformation.blockhash([3], %{exec_env: exec_env})
       0
-      iex> EVM.Operation.BlockInformation.blockhash([2], %{block_interface: block_interface})
+      iex> EVM.Operation.BlockInformation.blockhash([2], %{exec_env: exec_env})
       0
-      iex> EVM.Operation.BlockInformation.blockhash([1], %{block_interface: block_interface})
+      iex> EVM.Operation.BlockInformation.blockhash([1], %{exec_env: exec_env})
       "block_a"
-      iex> EVM.Operation.BlockInformation.blockhash([0], %{block_interface: block_interface})
+      iex> EVM.Operation.BlockInformation.blockhash([0], %{exec_env: exec_env})
       "gen_block"
-      iex> EVM.Operation.BlockInformation.blockhash([-1], %{block_interface: block_interface})
+      iex> EVM.Operation.BlockInformation.blockhash([-1], %{exec_env: exec_env})
       0
   """
   @spec blockhash(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def blockhash([block_number], %{block_interface: block_interface}) do
-    current_block_header = BlockInterface.get_block_header(block_interface)
-    parent_block_header = BlockInterface.get_block_by_hash(block_interface, current_block_header.parent_hash)
+  def blockhash([block_number], %{exec_env: exec_env}) do
+    current_block_header = BlockInterface.get_block_header(exec_env.block_interface)
+    parent_block_header = BlockInterface.get_block_by_hash(exec_env.block_interface, current_block_header.parent_hash)
 
-    get_block_number(block_interface, parent_block_header, current_block_header.parent_hash, block_number, 0)
+    get_block_number(exec_env.block_interface, parent_block_header, current_block_header.parent_hash, block_number, 0)
   end
 
   defp get_block_number(block_interface, block_header, parent_hash, block_number, depth) do
@@ -53,12 +54,13 @@ defmodule EVM.Operation.BlockInformation do
   ## Examples
 
       iex> block_interface = EVM.Interface.Mock.MockBlockInterface.new(%Block.Header{beneficiary: <<0x55::160>>})
-      iex> EVM.Operation.BlockInformation.coinbase([], %{block_interface: block_interface})
+      iex> exec_env = %EVM.ExecEnv{block_interface: block_interface}
+      iex> EVM.Operation.BlockInformation.coinbase([], %{exec_env: exec_env})
       <<0x55::160>>
   """
   @spec coinbase(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def coinbase(_args, %{block_interface: block_interface}) do
-    block_header = BlockInterface.get_block_header(block_interface)
+  def coinbase(_args, %{exec_env: exec_env}) do
+    block_header = BlockInterface.get_block_header(exec_env.block_interface)
 
     block_header.beneficiary
   end
@@ -69,12 +71,13 @@ defmodule EVM.Operation.BlockInformation do
   ## Examples
 
       iex> block_interface = EVM.Interface.Mock.MockBlockInterface.new(%Block.Header{timestamp: 1_000_000})
-      iex> EVM.Operation.BlockInformation.timestamp([], %{block_interface: block_interface})
+      iex> exec_env = %EVM.ExecEnv{block_interface: block_interface}
+      iex> EVM.Operation.BlockInformation.timestamp([], %{exec_env: exec_env})
       1_000_000
   """
   @spec timestamp(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def timestamp(_args, %{block_interface: block_interface}) do
-    block_header = BlockInterface.get_block_header(block_interface)
+  def timestamp(_args, %{exec_env: exec_env}) do
+    block_header = BlockInterface.get_block_header(exec_env.block_interface)
 
     block_header.timestamp
   end
@@ -85,12 +88,13 @@ defmodule EVM.Operation.BlockInformation do
   ## Examples
 
       iex> block_interface = EVM.Interface.Mock.MockBlockInterface.new(%Block.Header{number: 1_500_000})
-      iex> EVM.Operation.BlockInformation.number([], %{block_interface: block_interface})
+      iex> exec_env = %EVM.ExecEnv{block_interface: block_interface}
+      iex> EVM.Operation.BlockInformation.number([], %{exec_env: exec_env})
       1_500_000
   """
   @spec number(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def number(_args, %{block_interface: block_interface}) do
-    block_header = BlockInterface.get_block_header(block_interface)
+  def number(_args, %{exec_env: exec_env}) do
+    block_header = BlockInterface.get_block_header(exec_env.block_interface)
 
     block_header.number
   end
@@ -101,12 +105,13 @@ defmodule EVM.Operation.BlockInformation do
   ## Examples
 
       iex> block_interface = EVM.Interface.Mock.MockBlockInterface.new(%Block.Header{difficulty: 2_000_000})
-      iex> EVM.Operation.BlockInformation.difficulty([], %{block_interface: block_interface})
+      iex> exec_env = %EVM.ExecEnv{block_interface: block_interface}
+      iex> EVM.Operation.BlockInformation.difficulty([], %{exec_env: exec_env})
       2_000_000
   """
   @spec difficulty(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def difficulty(_args, %{block_interface: block_interface}) do
-    block_header = BlockInterface.get_block_header(block_interface)
+  def difficulty(_args, %{exec_env: exec_env}) do
+    block_header = BlockInterface.get_block_header(exec_env.block_interface)
 
     block_header.difficulty
   end
@@ -117,12 +122,13 @@ defmodule EVM.Operation.BlockInformation do
   ## Examples
 
       iex> block_interface = EVM.Interface.Mock.MockBlockInterface.new(%Block.Header{gas_limit: 3_000_000})
-      iex> EVM.Operation.BlockInformation.gaslimit([], %{block_interface: block_interface})
+      iex> exec_env = %EVM.ExecEnv{block_interface: block_interface}
+      iex> EVM.Operation.BlockInformation.gaslimit([], %{exec_env: exec_env})
       3_000_000
   """
   @spec gaslimit(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def gaslimit(_args, %{block_interface: block_interface}) do
-    block_header = BlockInterface.get_block_header(block_interface)
+  def gaslimit(_args, %{exec_env: exec_env}) do
+    block_header = BlockInterface.get_block_header(exec_env.block_interface)
 
     block_header.gas_limit
   end

--- a/lib/evm/operation/environmental_information.ex
+++ b/lib/evm/operation/environmental_information.ex
@@ -8,11 +8,11 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.address([], %{stack: [], exec_env: %EVM.ExecEnv{address: <<01, 00>>}})
+      iex> EVM.Operation.EnvironmentalInformation.address([], %{exec_env: %EVM.ExecEnv{address: <<01, 00>>}})
       <<1, 0>>
   """
   @spec address(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def address(_args, %{exec_env: exec_env}) do
+  def address([], %{exec_env: exec_env}) do
     exec_env.address
   end
 
@@ -48,46 +48,47 @@ defmodule EVM.Operation.EnvironmentalInformation do
   @doc """
   Get execution origination address.
 
-  TODO: Implement opcode
+  This is the sender of original transaction; it is never an account with non-empty associated code.
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.origin([], %{stack: []})
-      :unimplemented
+      iex> exec_env = %EVM.ExecEnv{originator: <<1::160>>, sender: <<2::160>>}
+      iex> EVM.Operation.EnvironmentalInformation.origin([], %{exec_env: exec_env})
+      <<1::160>>
   """
   @spec origin(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def origin(_args, %{stack: _stack}) do
-    :unimplemented
+  def origin([], %{exec_env: exec_env}) do
+    exec_env.originator
   end
 
   @doc """
   Get caller address.
 
-  TODO: Implement opcode
+  This is the address of the account that is directly responsible for this execution.
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.caller([], %{stack: []})
-      :unimplemented
+      iex> exec_env = %EVM.ExecEnv{originator: <<1::160>>, sender: <<2::160>>}
+      iex> EVM.Operation.EnvironmentalInformation.caller([], %{exec_env: exec_env})
+      <<2::160>>
   """
   @spec caller(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def caller(_args, %{stack: _stack}) do
-    :unimplemented
+  def caller([], %{exec_env: exec_env}) do
+    exec_env.sender
   end
 
   @doc """
-  Get deposited value by the instruction/transaction responsible for this execution.
-
-  TODO: Implement opcode
+  Get deposited value by the instruction / transaction responsible for this execution.
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.callvalue([], %{stack: []})
-      :unimplemented
+      iex> exec_env = %EVM.ExecEnv{value_in_wei: 1_000}
+      iex> EVM.Operation.EnvironmentalInformation.callvalue([], %{exec_env: exec_env})
+      1_000
   """
   @spec callvalue(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def callvalue(_args, %{stack: _stack}) do
-    :unimplemented
+  def callvalue([], %{exec_env: exec_env}) do
+    exec_env.value_in_wei
   end
 
   @doc """
@@ -97,27 +98,32 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for n <- 1..32, into: <<>>, do: <<255>>)}})
+      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for n <- 1..50, into: <<>>, do: <<255>>)}})
       -1
+
+      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for n <- 1..3, into: <<>>, do: <<1>>)}})
+      <<1::8, 1::8, 1::8, 0::232>> |> EVM.Helpers.decode_signed
+
+      iex> EVM.Operation.EnvironmentalInformation.calldataload([100], %{exec_env: %{data: (for n <- 1..3, into: <<>>, do: <<1>>)}})
+      0
   """
   @spec calldataload(Operation.stack_args, Operation.vm_map) :: Operation.op_result
   def calldataload([s0], %{exec_env: %{data: data}}) do
-    binary_part(data, s0, 32) |> Helpers.decode_signed
+    Helpers.read_zero_padded(data, s0, 32) |> Helpers.decode_signed
   end
 
   @doc """
   Get size of input data in current environment.
 
-  TODO: Implement opcode
-
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.calldatasize([], %{stack: []})
-      :unimplemented
+      iex> exec_env = %EVM.ExecEnv{data: "hello world"}
+      iex> EVM.Operation.EnvironmentalInformation.calldatasize([], %{exec_env: exec_env})
+      11
   """
   @spec calldatasize(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def calldatasize(_args, %{stack: _stack}) do
-    :unimplemented
+  def calldatasize([], %{exec_env: exec_env}) do
+    exec_env.data |> byte_size
   end
 
   @doc """
@@ -209,4 +215,5 @@ defmodule EVM.Operation.EnvironmentalInformation do
   def extcodecopy(_args, %{stack: _stack}) do
     :unimplemented
   end
+
 end

--- a/lib/evm/operation/environmental_information.ex
+++ b/lib/evm/operation/environmental_information.ex
@@ -98,13 +98,13 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for n <- 1..50, into: <<>>, do: <<255>>)}})
+      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for _ <- 1..50, into: <<>>, do: <<255>>)}})
       -1
 
-      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for n <- 1..3, into: <<>>, do: <<1>>)}})
+      iex> EVM.Operation.EnvironmentalInformation.calldataload([0], %{exec_env: %{data: (for _ <- 1..3, into: <<>>, do: <<1>>)}})
       <<1::8, 1::8, 1::8, 0::232>> |> EVM.Helpers.decode_signed
 
-      iex> EVM.Operation.EnvironmentalInformation.calldataload([100], %{exec_env: %{data: (for n <- 1..3, into: <<>>, do: <<1>>)}})
+      iex> EVM.Operation.EnvironmentalInformation.calldataload([100], %{exec_env: %{data: (for _ <- 1..3, into: <<>>, do: <<1>>)}})
       0
   """
   @spec calldataload(Operation.stack_args, Operation.vm_map) :: Operation.op_result

--- a/lib/evm/operation/environmental_information.ex
+++ b/lib/evm/operation/environmental_information.ex
@@ -1,6 +1,7 @@
 defmodule EVM.Operation.EnvironmentalInformation do
   alias EVM.Operation
   alias EVM.Helpers
+  alias EVM.Interface.AccountInterface
 
   @doc """
   Get address of currently executing account.
@@ -18,18 +19,30 @@ defmodule EVM.Operation.EnvironmentalInformation do
   @doc """
   Get balance of the given account.
 
-  TODO: Implement opcode
-
   ## Examples
 
-      iex> EVM.Operation.EnvironmentalInformation.balance([], %{stack: []})
-      :unimplemented
+      iex> db = MerklePatriciaTree.Test.random_ets_db()
+      iex> state = MerklePatriciaTree.Trie.new(db)
+      iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(balance: 500)
+      iex> exec_env = %EVM.ExecEnv{account_interface: account_interface}
+      iex> EVM.Operation.EnvironmentalInformation.balance([123], %{state: state, exec_env: exec_env})
+      500
+
+      iex> db = MerklePatriciaTree.Test.random_ets_db()
+      iex> state = MerklePatriciaTree.Trie.new(db)
+      iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(balance: nil)
+      iex> exec_env = %EVM.ExecEnv{account_interface: account_interface}
+      iex> EVM.Operation.EnvironmentalInformation.balance([123], %{state: state, exec_env: exec_env})
+      0
   """
   @spec balance(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def balance(_args, %{stack: _stack}) do
-    #   # stack |> state
-    #   # access state data
-    :unimplemented
+  def balance([address], %{state: state, exec_env: exec_env}) do
+    wrapped_address = Helpers.wrap_address(address)
+
+    case AccountInterface.get_account_balance(exec_env.account_interface, state, wrapped_address) do
+      nil -> 0
+      balance -> balance
+    end
   end
 
   @doc """

--- a/lib/evm/operation/system.ex
+++ b/lib/evm/operation/system.ex
@@ -6,10 +6,6 @@ defmodule EVM.Operation.System do
   alias EVM.Helpers
   alias EVM.Stack
 
-  use Bitwise
-
-  @max_address_mask round(:math.pow(2, 160)) - 1
-
   @doc """
   Create a new account with associated code.
 
@@ -94,7 +90,7 @@ defmodule EVM.Operation.System do
 
   def call(type, [call_gas, to, value, in_offset, in_size, out_offset, out_size], %{state: state, exec_env: exec_env, machine_state: machine_state}) when type in [:call, :call_code, :delegate_call] do
 
-    to_addr = (:binary.decode_unsigned(to) &&& @max_address_mask) |> :binary.encode_unsigned
+    to_addr = Helpers.wrap_address(to)
     {data, machine_state} = EVM.Memory.read(machine_state, in_offset, in_size)
     account_balance = AccountInterface.get_account_balance(exec_env.account_interface, state, exec_env.address)
     block_header = BlockInterface.get_block_header(exec_env.block_interface)

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -185,4 +185,21 @@ defmodule EVM.Helpers do
         binary_part(data, start_pos, read_length)
     end
   end
+
+  @doc """
+  Defined as Eq.(224) in the Yellow Paper, this is "all but one 64th",
+  written as L(x).
+
+  ## Examples
+
+      iex> EVM.Helpers.all_but_one_64th(5)
+      5
+
+      iex> EVM.Helpers.all_but_one_64th(1000)
+      1000
+  """
+  @spec all_but_one_64th(integer()) :: integer()
+  def all_but_one_64th(n) do
+    n - :math.floor(n / 64)
+  end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -101,7 +101,7 @@ defmodule EVM.Helpers do
       1
   """
   def wrap_address(n) when is_integer(n), do: band(n, EVM.max_address() - 1)
-  def wrap_address(n) when is_binary(n), do: band(n |> :binary.decode_unsigned, EVM.max_address() - 1) |> :binary.encode_unsigned
+  def wrap_address(n) when is_binary(n), do: n |> :binary.decode_unsigned |> wrap_address |> :binary.encode_unsigned
 
   @doc """
   Encodes signed ints using twos compliment

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -149,4 +149,40 @@ defmodule EVM.Helpers do
 
     msg
   end
+
+  @doc """
+  Reads a length of data from a binary, filling in all unknown values as zero.
+
+  ## Examples
+
+      iex> EVM.Helpers.read_zero_padded(<<5, 6, 7>>, 1, 3)
+      <<6, 7, 0>>
+
+      iex> EVM.Helpers.read_zero_padded(<<5, 6, 7>>, 0, 2)
+      <<5, 6>>
+
+      iex> EVM.Helpers.read_zero_padded(<<5, 6, 7>>, 0, 3)
+      <<5, 6, 7>>
+
+      iex> EVM.Helpers.read_zero_padded(<<5, 6, 7>>, 4, 3)
+      <<0, 0, 0>>
+  """
+  @spec read_zero_padded(binary(), integer(), integer()) :: binary()
+  def read_zero_padded(data, start_pos, read_length) do
+    end_pos = start_pos + read_length
+    total_data_length = byte_size(data)
+
+    cond do
+      start_pos > total_data_length ->
+        total_bits = read_length * 8
+
+        <<0::size(total_bits)>>
+      end_pos > total_data_length ->
+        data_read_length = total_data_length - start_pos
+        padding = ( read_length - data_read_length ) * 8
+        binary_part(data, start_pos, data_read_length) <> <<0::size(padding)>>
+      true ->
+        binary_part(data, start_pos, read_length)
+    end
+  end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -196,10 +196,10 @@ defmodule EVM.Helpers do
       5
 
       iex> EVM.Helpers.all_but_one_64th(1000)
-      1000
+      985
   """
   @spec all_but_one_64th(integer()) :: integer()
   def all_but_one_64th(n) do
-    n - :math.floor(n / 64)
+    round(n - :math.floor(n / 64))
   end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -87,6 +87,23 @@ defmodule EVM.Helpers do
   def wrap_int(n), do: n
 
   @doc """
+  Wrap ints greater than the maximum allowed address size.
+
+  ## Examples
+
+      iex> EVM.Helpers.wrap_address(1)
+      1
+
+      iex> EVM.Helpers.wrap_address(<<1>>)
+      <<1>>
+
+      iex> EVM.Helpers.wrap_address(EVM.max_address() + 1)
+      1
+  """
+  def wrap_address(n) when is_integer(n), do: band(n, EVM.max_address() - 1)
+  def wrap_address(n) when is_binary(n), do: band(n |> :binary.decode_unsigned, EVM.max_address() - 1) |> :binary.encode_unsigned
+
+  @doc """
   Encodes signed ints using twos compliment
 
   ## Examples

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule EVM.Mixfile do
 
   def project do
     [app: :evm,
-     version: "0.1.4",
+     version: "0.1.5",
      elixir: "~> 1.4",
      description: "Ethereum's Virtual Machine, in all its glory.",
       package: [

--- a/test/evm_test.exs
+++ b/test/evm_test.exs
@@ -10,8 +10,8 @@ defmodule EvmTest do
 
 
   test "Ethereum Common Tests" do
-    for {test_group_name, test_group} <- @passing_tests_by_group do
-      for {test_name, test} <- passing_tests(test_group_name) do
+    for {test_group_name, _test_group} <- @passing_tests_by_group do
+      for {_test_name, test} <- passing_tests(test_group_name) do
         db = MerklePatriciaTree.Test.random_ets_db()
         state = EVM.VM.run(
           MerklePatriciaTree.Trie.new(db),
@@ -33,7 +33,7 @@ defmodule EvmTest do
 
   def passing_tests(test_group_name) do
     read_test_file(test_group_name)
-      |> Enum.filter(fn({test_name, test}) ->
+      |> Enum.filter(fn({test_name, _test}) ->
         passing_tests_in_group = Map.get(@passing_tests_by_group, test_group_name)
 
         passing_tests_in_group == :all ||


### PR DESCRIPTION
This patch finalizes the interfaces for `AccountInterface`, `BlockInterface` and `ContractInterface`. It turns out they probably could have been done using a simpler `@behaviour` instead of `defprotocol` method (since they didn't actually need to track global state that I thought they did). But, it makes for a very clean dependency injection system for testing with `EVM` and no real blockchain, so I'm inclined to keep it the way it is.

Also, we add a basic implementation of `CREATE`. With that, we have `CREATE`, `CALL`, `CALLCODE` and `DELEGATECALL` all at about 80% complete (missing receipts, logs and a plethora of testing).