### PR TITLE
Add decompile functionality

### DIFF
--- a/lib/evm/operation.ex
+++ b/lib/evm/operation.ex
@@ -178,7 +178,7 @@ defmodule EVM.Operation do
       %EVM.Operation.Metadata{id: 0x01, sym: :add, input_count: 2, output_count: 1, description: "Addition operation", group: :stop_and_arithmetic}
 
       iex> EVM.Operation.metadata(:push1)
-      %EVM.Operation.Metadata{id: 0x60, sym: :push1, fun: :push_n, args: [1], input_count: 0, output_count: 1, description: "Place 1-byte item on stack", group: :push}
+      %EVM.Operation.Metadata{id: 0x60, sym: :push1, fun: :push_n, args: [1], input_count: 0, output_count: 1, description: "Place 1-byte item on stack", group: :push, machine_code_offset: 1}
 
       iex> EVM.Operation.metadata(0xfe)
       nil

--- a/lib/evm/operation/metadata.ex
+++ b/lib/evm/operation/metadata.ex
@@ -11,7 +11,8 @@ defmodule EVM.Operation.Metadata do
     input_count: nil,
     output_count: nil,
     description: nil,
-    group: :other
+    group: :other,
+    machine_code_offset: nil
   ]
 
   @type t :: %__MODULE__{
@@ -22,6 +23,7 @@ defmodule EVM.Operation.Metadata do
     :input_count => integer(), # Denoted as δin the Yellow Paper
     :output_count => integer(), # Denoted as αin the Yellow Paper
     :description => String.t,
-    :group => atom()
+    :group => atom(),
+    :machine_code_offset => integer() | nil
   }
 end

--- a/lib/evm/operation/metadata/push.ex
+++ b/lib/evm/operation/metadata/push.ex
@@ -8,7 +8,8 @@ defmodule EVM.Operation.Metadata.Push do
       args: [n],
       input_count: 0,
       output_count: 1,
-      group: :push
+      group: :push,
+      machine_code_offset: n
     }
   def operations, do: @operations
 end


### PR DESCRIPTION
This patch adds a very simple decompile function. As we're starting to run real transactions from the blockchain, it's worth being able to decompile the machine code and see why the code is failing or succeeding. As such, this functionality is helpful (and the added test case is from the real Ropsten chain on block 11).