### PR TITLE
Add in a full debugger to the EVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.7
+* Add in a full debugger
 # 0.1.6
 * Add in parameters that could be tweaked by different chains (e.g. `min_gas_limit` in Ropsten)
 * Add Bitwise logic opcodes and SHA3

--- a/lib/evm/debugger.ex
+++ b/lib/evm/debugger.ex
@@ -1,0 +1,373 @@
+defmodule EVM.Debugger do
+  @moduledoc """
+  A first-class debugger for the EVM. We are able to set
+  breakpoints and walk through code execution.
+  """
+
+  alias EVM.Debugger.Breakpoint
+  alias EVM.Debugger.Command
+
+  @commands [
+    %Command{command: :next, name: "next", shortcut: "n", description: "Run this operation and break on next operation."},
+    %Command{command: :continue, name: "continue", shortcut: "c", description: "Stop debugging and continue operation of program."},
+    %Command{command: :debug, name: "debug", shortcut: "d", description: "Show detailed debug environment information."},
+    %Command{command: :stack, name: "stack", shortcut: "s", description: "Show current program stack."},
+    %Command{command: :pc, name: "pc", shortcut: "p", description: "Show current program pc."},
+    %Command{command: :help, name: "help", shortcut: "h", description: "Show this help screen."},
+    %Command{command: :where, name: "where", shortcut: "w", description: "Show where pc is in the currently executing code. (optional args: `where [length]`)"},
+    %Command{command: :machine_state, name: "machine", description: "Prints the current machine state."},
+    %Command{command: :memory, name: "memory", shortcut: "m", description: "Prints the current machine's memory."},
+  ]
+
+  @current_instruction_start 3
+  @current_instruction_length 10
+  @chunk_size 10
+
+  @doc """
+  Enables the debugger.
+
+  Note: the debugger should only be run when debugging; it may
+        seriously degrade performance of the VM during normal
+        operations.
+
+  ## Examples
+
+      iex> EVM.Debugger.enable
+      :ok
+      iex> EVM.Debugger.is_enabled?
+      true
+      iex> EVM.Debugger.disable
+      :ok
+      iex> EVM.Debugger.enable
+      :ok
+      iex> EVM.Debugger.disable
+      :ok
+  """
+  @spec enable() :: :ok
+  def enable() do
+    Application.put_env(__MODULE__, :enabled, true)
+
+    EVM.Debugger.Breakpoint.init()
+  end
+
+  @doc """
+  Disables the debugger.
+
+  ## Examples
+
+      iex> EVM.Debugger.disable
+      :ok
+      iex> EVM.Debugger.enable
+      :ok
+      iex> EVM.Debugger.disable
+      :ok
+  """
+  @spec disable() :: :ok
+  def disable() do
+    Application.put_env(__MODULE__, :enabled, false)
+  end
+
+  @doc """
+  Returns true only if debugging is currently enabled.
+
+  This is set in the application config.
+
+  ## Examples
+
+      iex> Application.put_env(EVM.Debugger, :enabled, true)
+      iex> EVM.Debugger.is_enabled?
+      true
+      iex> Application.put_env(EVM.Debugger, :enabled, false)
+      :ok
+
+      iex> Application.put_env(EVM.Debugger, :enabled, false)
+      iex> EVM.Debugger.is_enabled?
+      false
+
+      iex> EVM.Debugger.is_enabled?
+      false
+  """
+  @spec is_enabled?() :: boolean()
+  def is_enabled? do
+    Application.get_env(__MODULE__, :enabled, false)
+  end
+
+  @doc """
+  Sets a new breakpoint based on supplied conditions.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.break_on(address: <<188, 31, 252, 22, 32, 218, 20, 104, 98, 74, 89, 108, 184, 65, 211, 94, 107, 47, 31, 182>>)
+      iex> EVM.Debugger.Breakpoint.get_breakpoint(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<188, 31, 252, 22, 32, 218, 20, 104, 98, 74, 89, 108, 184, 65, 211, 94, 107, 47, 31, 182>>], pc: :start}
+  """
+  @spec break_on(keyword(Breakpoint.conditions)) :: Breakpoint.t
+  def break_on(conditions) do
+    Breakpoint.set_breakpoint(%Breakpoint{conditions: conditions, pc: :start})
+  end
+
+  @doc """
+  Return true if the currently line of code is tripped by
+  any previously set breakpoint.
+
+  ## Examples
+
+      iex> EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<25::160>>], pc: :next})
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<25::160>>}
+      iex> EVM.Debugger.is_breakpoint?(state, machine_state, sub_state, exec_env) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<25::160>>], pc: :next}
+
+      iex> EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<25::160>>], enabled: false})
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<26::160>>}
+      iex> EVM.Debugger.is_breakpoint?(state, machine_state, sub_state, exec_env)
+      :continue
+  """
+  @spec is_breakpoint?(EVM.state, MachineState.t, SubState.t, ExecEnv.t) :: :continue | Breakpoint.t
+  def is_breakpoint?(state, machine_state, sub_state, exec_env) do
+    Enum.find(Breakpoint.get_breakpoints(), :continue, fn breakpoint ->
+      Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+    end)
+  end
+
+  @doc """
+  Breaks execution and begins a REPL to interact with the currently executing code.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<25::160>>], enabled: false})
+      iex> breakpoint = EVM.Debugger.Breakpoint.get_breakpoint(id)
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<26::160>>}
+      iex> EVM.Debugger.break(breakpoint, state, machine_state, sub_state, exec_env, ["continue"])
+      { <<>>, %EVM.MachineState{}, %EVM.SubState{}, %EVM.ExecEnv{address: <<26::160>>} }
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<25::160>>], enabled: false})
+      iex> breakpoint = EVM.Debugger.Breakpoint.get_breakpoint(id)
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<26::160>>}
+      iex> EVM.Debugger.break(breakpoint, state, machine_state, sub_state, exec_env, ["zzzzzzz", "continue"])
+      { <<>>, %EVM.MachineState{}, %EVM.SubState{}, %EVM.ExecEnv{address: <<26::160>>} }
+  """
+  @spec break(Breakpoint.t, EVM.state, MachineState.t, SubState.t, ExecEnv.t, [String.t]) :: { EVM.state, MachineState.t, SubState.t, ExecEnv.t }
+  def break(breakpoint, state, machine_state, sub_state, exec_env, input_sequence \\ []) do
+    Breakpoint.clear_pc_if_one_time_break(breakpoint.id)
+
+    if breakpoint.pc == :start do
+      # If we're not next, we're likely a freshly hit breakpoint and should display a helpful prompt
+      # to the user.
+      IO.puts("\n\n-- Breakpoint ##{breakpoint.id} triggered with conditions #{Breakpoint.describe(breakpoint)} --")
+    end
+
+    IO.puts("")
+    print_machine_state(machine_state)
+    IO.puts("")
+    print_current_instruction(exec_env, machine_state)
+
+    if breakpoint.pc == :start do
+      IO.puts("Enter a debug command or type `h` for help.")
+      IO.puts("")
+    end
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  @spec print_machine_state(MachineState.t) :: any()
+  def print_machine_state(machine_state) do
+    IO.puts "gas: #{machine_state.gas} | pc: #{machine_state.pc} | memory: #{machine_state.memory |> byte_size} | words: #{machine_state.active_words} | # stack: #{machine_state.stack |> Enum.count}"
+  end
+
+  @spec print_current_instruction(MachineState.t, ExecEnv.t, integer(), integer()) :: any()
+  defp print_current_instruction(exec_env, machine_state, start \\ @current_instruction_start, len \\ @current_instruction_length) do
+    if is_nil(machine_state.pc) do
+      IO.puts("??? invalid pc ???")
+      IO.puts("")
+    else
+      machine_code = EVM.MachineCode.decompile(exec_env.machine_code)
+      index_width = if machine_code == [], do: 0, else: machine_code |> Enum.count |> :math.log10 |> :math.ceil |> round
+
+      machine_code
+      |> Enum.with_index
+      |> Enum.slice(max(machine_state.pc - start, 0), len)
+      |> Enum.each(fn {instruction, index} ->
+        pointer = if machine_state.pc == index, do: "----> ", else: "      "
+        instruction_str = instruction |> to_string
+        index_str = "[#{index |> to_string |> String.pad_leading(index_width)}] "
+
+        IO.puts("#{pointer}#{index_str}#{instruction_str}")
+      end)
+      IO.puts("")
+    end
+  end
+
+  @spec prompt(Breakpoint.t, EVM.state, MachineState.t, SubState.t, ExecEnv.t, [String.t]) :: { EVM.state, MachineState.t, SubState.t, ExecEnv.t }
+  defp prompt(breakpoint, state, machine_state, sub_state, exec_env, [input | rest]), do: handle_input(input, breakpoint, state, machine_state, sub_state, exec_env, rest)
+  defp prompt(breakpoint, state, machine_state, sub_state, exec_env, []) do
+    IO.gets(">> ")
+    |> handle_input(breakpoint, state, machine_state, sub_state, exec_env, [])
+  end
+
+  @spec handle_input(String.t, Breakpoint.t, EVM.state, MachineState.t, SubState.t, ExecEnv.t, [String.t]) :: { EVM.state, MachineState.t, SubState.t, ExecEnv.t }
+  def handle_input(input, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    case String.split(input |> String.trim, " ", trim: true) do
+      [] -> prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+      [command_string|args] ->
+        command = Enum.find(@commands, fn command ->
+          command.name == command_string or command.shortcut == String.first(command_string)
+        end)
+
+        if command do
+          handle_prompt(command.command, args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+        else
+          IO.puts("unknown command: `#{command_string}`")
+
+          prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+        end
+    end
+  end
+
+  # Handle prompt passes the prompt information bac
+  @spec handle_prompt(atom(), [String.t], Breakpoint.t, EVM.state, MachineState.t, SubState.t, ExecEnv.t, [String.t]) :: { EVM.state, MachineState.t, SubState.t, ExecEnv.t }
+  defp handle_prompt(command, args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+
+  defp handle_prompt(:help, _args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    # TODO: Handle args, make nicer
+
+    IO.puts("")
+    IO.puts("The EVM Debugger helps you understand a message or contract call in the EVM. Please choose a command from the following list of options:")
+    IO.puts("")
+
+    for command <- @commands do
+      [
+        command.name,
+        (if command.shortcut, do: "(#{command.shortcut})", else: nil),
+        "-",
+        command.description
+      ]
+      |> Enum.filter(fn s -> not is_nil(s) end)
+      |> Enum.join(" ")
+      |> IO.puts
+    end
+
+    IO.puts("")
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:debug, _args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    IO.inspect([state, machine_state, sub_state, exec_env], limit: :infinity)
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:stack, _args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    IO.puts("")
+    IO.puts("Machine Stack")
+
+    stack_length = machine_state.stack |> Enum.count
+    tail = stack_length - 1
+
+    case machine_state.stack do
+      [] -> IO.puts("<empty>")
+      stack ->
+        width =
+          machine_state.stack
+          |> Enum.map(fn v -> v |> to_string |> String.length end)
+          |> Enum.max
+
+        for {v, i} <- stack |> Enum.with_index do
+          heading = case i do
+            0 -> "HEAD ->"
+            ^tail -> "TAIL ->"
+            _ -> "       "
+          end
+
+          IO.puts("#{heading} #{String.pad_leading(to_string(v), width)}")
+        end
+    end
+
+    IO.puts("")
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:memory, _args, breakpoint, state, machine_state=%EVM.MachineState{memory: memory}, sub_state, exec_env, input_sequence) do
+    total_size = byte_size(memory)
+    size_width = if total_size > 0, do: total_size |> :math.log10 |> :math.ceil |> round, else: 0
+
+    IO.puts("")
+    IO.puts("Memory (#{total_size} #{if total_size == 1, do: "byte", else: "bytes"})")
+    IO.puts("")
+
+    for {chunk, n} <- Enum.chunk(memory |> String.codepoints, @chunk_size, @chunk_size, []) |> Enum.with_index do
+      offset = n * @chunk_size
+
+      ascii =
+        chunk
+        |> Enum.map(fn codepoint -> if codepoint |> String.to_charlist |> List.first |> printable, do: codepoint, else: "." end)
+        |> Enum.join
+        |> String.pad_leading(@chunk_size)
+
+      hex =
+        chunk
+        |> Enum.map(fn codepoint -> Base.encode16(codepoint) end)
+        |> Enum.join(" ")
+        |> String.pad_leading(@chunk_size * 3, " ")
+
+      IO.puts "[#{String.pad_leading(offset |> to_string, size_width)}] #{hex} #{ascii}"
+    end
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:machine_state, _args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    print_machine_state(machine_state)
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:pc, _args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    IO.puts("The current program count is: #{machine_state.pc}")
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:where, args, breakpoint, state, machine_state, sub_state, exec_env, input_sequence) do
+    len = case Enum.at(args, 0, nil) do
+      nil -> @current_instruction_length
+      str ->
+        case Integer.parse(str) do
+          {len, ""} -> len
+          _els -> @current_instruction_length
+        end
+    end
+
+    print_current_instruction(exec_env, machine_state, @current_instruction_start, len * 2)
+
+    prompt(breakpoint, state, machine_state, sub_state, exec_env, input_sequence)
+  end
+
+  defp handle_prompt(:next, _args, breakpoint, state, machine_state, sub_state, exec_env, _input_sequence) do
+    Breakpoint.set_next(breakpoint.id)
+
+    { state, machine_state, sub_state, exec_env }
+  end
+
+  defp handle_prompt(:continue, _args, _breakpoint, state, machine_state, sub_state, exec_env, _input_sequence) do
+    { state, machine_state, sub_state, exec_env }
+  end
+
+  @spec printable(integer()) :: boolean()
+  defp printable(x) when x in 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789', do: true
+  defp printable(_), do: false
+
+end

--- a/lib/evm/debugger/breakpoint.ex
+++ b/lib/evm/debugger/breakpoint.ex
@@ -1,0 +1,312 @@
+defmodule EVM.Debugger.Breakpoint do
+  @moduledoc """
+  Breakpoints allow us to break execution of a given
+  contract based on a set of conditions.
+  """
+
+  @table __MODULE__
+
+  @type id :: integer()
+
+  @type conditions :: [
+    :address, # only triggers when contract executes at given address
+  ]
+
+  @type t :: %__MODULE__{
+    id: id,
+    enabled: boolean(),
+    conditions: keyword(conditions),
+    pc: nil | :start | :next | integer()
+  }
+
+  defstruct [
+    id: nil,
+    enabled: true,
+    conditions: [],
+    pc: nil
+  ]
+
+  @doc """
+  Initializes the debugger. Must be called prior to getting or checking
+  breakpoints.
+  """
+  @spec init() :: :ok
+  def init() do
+    case :ets.info(@table) do
+      :undefined -> :ets.new(@table, [:ordered_set, :public, :named_table])
+      _info -> :table_exists
+    end
+
+    :ok
+  end
+
+  @doc """
+  Adds a global breakpoint condition.
+
+  We can set the following types of breakpoints:
+  ...
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<15::160>>]})
+      iex> EVM.Debugger.Breakpoint.get_breakpoint(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<15::160>>]}
+  """
+  @spec set_breakpoint(t) :: id
+  def set_breakpoint(breakpoint) do
+    id = next_id()
+    true = :ets.insert_new(@table, {id, %{breakpoint | id: id}})
+    id
+  end
+
+  @doc """
+  Gets a breakpoint by id. This will raise if no such breakpoint
+  is found.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>]})
+      iex> EVM.Debugger.Breakpoint.get_breakpoint(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>]}
+
+      iex> EVM.Debugger.Breakpoint.get_breakpoint(999)
+      ** (CaseClauseError) no case clause matching: []
+  """
+  @spec get_breakpoint(id) :: t
+  def get_breakpoint(breakpoint_id) do
+    case :ets.lookup(@table, breakpoint_id) do
+      [{_id, breakpoint}] -> breakpoint
+    end
+  end
+
+  @doc """
+  Returns true if a given breakpoint matches the current execution environment.
+
+  Note: we currently only support address matching.
+
+  ## Examples
+
+      iex> breakpoint = %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: :next}
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<20::160>>}
+      iex> EVM.Debugger.Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+      true
+
+      iex> breakpoint = %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: 999}
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<20::160>>}
+      iex> EVM.Debugger.Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+      false
+
+      iex> breakpoint = %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: 999}
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{pc: 999}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<20::160>>}
+      iex> EVM.Debugger.Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+      true
+
+      iex> breakpoint = %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: nil}
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{pc: 999}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<20::160>>}
+      iex> EVM.Debugger.Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+      false
+
+      iex> breakpoint = %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], enabled: false, pc: :next}
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<20::160>>}
+      iex> EVM.Debugger.Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+      false
+
+      iex> breakpoint = %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: :next}
+      iex> state = <<>>
+      iex> machine_state = %EVM.MachineState{}
+      iex> sub_state = %EVM.SubState{}
+      iex> exec_env = %EVM.ExecEnv{address: <<21::160>>}
+      iex> EVM.Debugger.Breakpoint.matches?(breakpoint, state, machine_state, sub_state, exec_env)
+      false
+  """
+  @spec matches?(t, EVM.state, EVM.MachineState.t, EVM.SubState.t, EVM.ExecEnv.t) :: boolean()
+  def matches?(breakpoint, state, machine_state, sub_state, exec_env) do
+    breakpoint.enabled and break_on_next_pc?(breakpoint, machine_state.pc) and Enum.all?(breakpoint.conditions, fn {condition, condition_val} ->
+      case condition do
+        :address -> exec_env.address == condition_val
+      end
+    end)
+  end
+
+  @doc """
+  Describes a breakpoint's trigger conditions.
+
+  ## Examples
+
+      iex> %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: :next} |> EVM.Debugger.Breakpoint.describe
+      "contract address 0x0000000000000000000000000000000000000014 (next)"
+
+      iex> %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: :start} |> EVM.Debugger.Breakpoint.describe
+      "contract address 0x0000000000000000000000000000000000000014 (start)"
+
+      iex> %EVM.Debugger.Breakpoint{conditions: [address: <<20::160>>], pc: nil} |> EVM.Debugger.Breakpoint.describe
+      "contract address 0x0000000000000000000000000000000000000014 (waiting)"
+
+      iex> %EVM.Debugger.Breakpoint{conditions: [], pc: nil} |> EVM.Debugger.Breakpoint.describe
+      "(waiting)"
+  """
+  @spec describe(t) :: String.t
+  def describe(breakpoint) do
+    conditions = for {k, v} <- breakpoint.conditions do
+      case k do
+        :address -> "contract address 0x#{Base.encode16(v, case: :lower)}"
+      end
+    end |> Enum.join(" ")
+
+    state = case breakpoint.pc do
+      :next -> "next"
+      :start -> "start"
+      nil -> "waiting"
+    end
+
+    "#{conditions} (#{state})" |> String.trim
+  end
+
+  @doc """
+  Returns all active breakpoints.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>]})
+      iex> breakpoint = EVM.Debugger.Breakpoint.get_breakpoint(id)
+      iex> breakpoints = EVM.Debugger.Breakpoint.get_breakpoints()
+      iex> breakpoints |> Enum.count > 0
+      true
+      iex> breakpoints |> Enum.member?(breakpoint)
+      true
+  """
+  @spec get_breakpoints() :: [Breakpoint.t]
+  def get_breakpoints() do
+    :ets.foldl(fn {id, breakpoint}, acc ->
+      [breakpoint | acc]
+    end, [], @table)
+  end
+
+  @doc """
+  Disables a given breakpoint.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>]})
+      iex> EVM.Debugger.Breakpoint.disable_breakpoint(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], enabled: false}
+  """
+  @spec disable_breakpoint(id) :: Breakpoint.t
+  def disable_breakpoint(breakpoint_id) do
+    update_breakpoint(breakpoint_id, fn(breakpoint) ->
+      %{breakpoint | enabled: false}
+    end)
+  end
+
+  @doc """
+  Enables a given breakpoint.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], enabled: false})
+      iex> EVM.Debugger.Breakpoint.enable_breakpoint(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], enabled: true}
+  """
+  @spec enable_breakpoint(id) :: Breakpoint.t
+  def enable_breakpoint(breakpoint_id) do
+    update_breakpoint(breakpoint_id, fn(breakpoint) ->
+      %{breakpoint | enabled: true}
+    end)
+  end
+
+  @doc """
+  Sets the pc to next so that this breakpoint
+  will likely break on the next run.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>]})
+      iex> EVM.Debugger.Breakpoint.set_next(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: :next}
+  """
+  @spec set_next(id) :: Breakpoint.t
+  def set_next(breakpoint_id) do
+    update_breakpoint(breakpoint_id, fn breakpoint ->
+      %{breakpoint | pc: :next}
+    end)
+  end
+
+  @doc """
+  Clears the pc so that this breakpoint doesn't continue breaking.
+
+  ## Examples
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: :next})
+      iex> EVM.Debugger.Breakpoint.clear_pc_if_one_time_break(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: nil}
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: :start})
+      iex> EVM.Debugger.Breakpoint.clear_pc_if_one_time_break(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: nil}
+
+      iex> id = EVM.Debugger.Breakpoint.set_breakpoint(%EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: 5})
+      iex> EVM.Debugger.Breakpoint.clear_pc_if_one_time_break(id) |> Map.put(:id, nil)
+      %EVM.Debugger.Breakpoint{conditions: [address: <<1::160>>], pc: 5}
+  """
+  @spec clear_pc_if_one_time_break(id) :: Breakpoint.t
+  def clear_pc_if_one_time_break(breakpoint_id) do
+    update_breakpoint(breakpoint_id, fn breakpoint ->
+      if breakpoint.pc in [:start, :next] do
+        %{breakpoint | pc: nil}
+      else
+        breakpoint
+      end
+    end)
+  end
+
+  @spec update_breakpoint(id, (t -> t)) :: t
+  defp update_breakpoint(breakpoint_id, fun) do
+    breakpoint = get_breakpoint(breakpoint_id)
+
+    updated_breakpoint = fun.(breakpoint)
+
+    :ets.insert(@table, {breakpoint.id, updated_breakpoint})
+
+    updated_breakpoint
+  end
+
+  # Returns a new id for the next breakpoint
+  @spec next_id() :: id
+  defp next_id() do
+    case :ets.last(@table) do
+      :"$end_of_table" -> 1
+      key -> key + 1
+    end
+  end
+
+  # Returns true if we should break on the next instruction
+
+  # This is will be true if we're instructed to break on :next or :start, or
+  # when the machine's breakpoint's pc matches the machine's pc.
+  @spec break_on_next_pc?(t, EVM.MachineState.pc) :: boolean()
+  def break_on_next_pc?(breakpoint, pc) do
+    case breakpoint.pc do
+      nil -> false
+      :next -> true
+      :start -> true
+      ^pc -> true
+      _ -> false
+    end
+  end
+
+end

--- a/lib/evm/debugger/command.ex
+++ b/lib/evm/debugger/command.ex
@@ -1,0 +1,19 @@
+defmodule EVM.Debugger.Command do
+  @moduledoc """
+  Defines a command that can be run in the debugger.
+  """
+
+  @type t :: %__MODULE__{
+    command: atom(),
+    name: String.t,
+    shortcut: String.t,
+    description: String.t,
+  }
+
+  defstruct [
+    command: nil,
+    name: nil,
+    shortcut: nil,
+    description: nil,
+  ]
+end

--- a/test/evm/breakpoint/breakpoint_test.exs
+++ b/test/evm/breakpoint/breakpoint_test.exs
@@ -1,0 +1,11 @@
+defmodule EVM.Debugger.BreakpointTest do
+  use ExUnit.Case, async: true
+  doctest EVM.Debugger.Breakpoint
+
+  setup_all do
+    EVM.Debugger.Breakpoint.init()
+
+    :ok
+  end
+
+end

--- a/test/evm/debugger_test.exs
+++ b/test/evm/debugger_test.exs
@@ -1,0 +1,11 @@
+defmodule EVM.DebuggerTest do
+  use ExUnit.Case, async: true
+  doctest EVM.Debugger
+
+  setup_all do
+    EVM.Debugger.Breakpoint.init()
+
+    :ok
+  end
+
+end


### PR DESCRIPTION
This patch adds a first-class debugger to the EVM. As we are starting to run real transactions from the blockchain, it's becoming more and more important that we can walk through the execution of these contracts to understand the effects as they are run. I expect this debugger to grow into a full first-class debugger (imagine being able to change code inline as you debug it, move the PC, set more interesting breakpoints, etc). This debugger is currently working and lets you set and walk through breakpoints on live code.