### PR TITLE
Account Interface Updates & 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.10
+* Update interfaces to match `Blockchain` downstream
+* Add `Block.Header.hash/1` function
 # 0.1.9
 * Subtract gas before running operations
 * Move program counter logic to its own module

--- a/lib/evm/interface/account_interface.ex
+++ b/lib/evm/interface/account_interface.ex
@@ -8,7 +8,7 @@ defprotocol EVM.Interface.AccountInterface do
   @spec get_account_balance(t, EVM.state, EVM.address) :: nil | EVM.Wei.t
   def get_account_balance(t, state, address)
 
-  @spec get_account_code(t, EVM.state, EVM.address) :: nil | integer()
+  @spec get_account_code(t, EVM.state, EVM.address) :: nil | binary()
   def get_account_code(t, state, address)
 
   @spec increment_account_nonce(t, EVM.state, EVM.address) :: { EVM.state, integer() }

--- a/lib/evm/interface/mock/mock_account_interface.ex
+++ b/lib/evm/interface/mock/mock_account_interface.ex
@@ -24,7 +24,7 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
     end
   end
 
-  @spec get_account_code(EVM.Interface.AccountInterface.t, EVM.state, EVM.address) :: nil | integer()
+  @spec get_account_code(EVM.Interface.AccountInterface.t, EVM.state, EVM.address) :: nil | binary()
   def get_account_code(mock_account_interface, _state, address) do
     account = get_account(mock_account_interface, address)
 

--- a/lib/evm/operation/environmental_information.ex
+++ b/lib/evm/operation/environmental_information.ex
@@ -203,7 +203,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
 
   ## Examples
 
-      iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(%{account_map: %{0x01 => %{code: 0x11223344}}})
+      iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(%{account_map: %{0x01 => %{code: <<0x11, 0x22, 0x33, 0x44>>}}})
       iex> db = MerklePatriciaTree.Test.random_ets_db()
       iex> state = MerklePatriciaTree.Trie.new(db)
       iex> exec_env = %EVM.ExecEnv{account_interface: account_interface}
@@ -217,7 +217,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
     account_code = AccountInterface.get_account_code(exec_env.account_interface, state, wrapped_address)
 
     if account_code do
-      byte_size(:binary.encode_unsigned(account_code))
+      byte_size(account_code)
     else
       0
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule EVM.Mixfile do
 
   def project do
     [app: :evm,
-     version: "0.1.9",
+     version: "0.1.10",
      elixir: "~> 1.4",
      description: "Ethereum's Virtual Machine, in all its glory.",
       package: [

--- a/test/evm_test.exs
+++ b/test/evm_test.exs
@@ -112,14 +112,14 @@ defmodule EvmTest do
     account_map = %{
       hex_to_int(test["exec"]["caller"]) => %{
         balance: 0,
-        code: hex_to_int(test["exec"]["code"]),
+        code: hex_to_binary(test["exec"]["code"]),
         nonce: 0,
     }}
     account_map = Enum.reduce(test["pre"], account_map, fn({address, account}, address_map) ->
       Map.merge(address_map, %{
           hex_to_int(address) => %{
             balance: hex_to_int(account["balance"]),
-            code: hex_to_int(account["code"]),
+            code: hex_to_binary(account["code"]),
             nonce: hex_to_int(account["nonce"]),
           }
         })


### PR DESCRIPTION
Minor updates to the account interface to make sure it always returns a binary. We bump to 0.1.10 so that we can effectively update these interfaces downstream in exthereum/blockchain.