### PR TITLE
Add multiple accounts to `state`

### DIFF
--- a/lib/evm.ex
+++ b/lib/evm.ex
@@ -3,7 +3,15 @@ defmodule EVM do
   Documentation for EVM.
   """
 
-  @type state :: MerklePatriciaTree.Trie.t
+  @type account :: %{                                  #σ[a]
+    :nonce => integer(),                               #σ[a]n
+    :balance => integer(),                             #σ[a]b
+    :storage => MerklePatriciaTree.Trie.t,             #σ[a]s
+    :code => binary(),                                 #σ[a]c
+  }
+  @type world_state :: %{                               # σ
+    binary() => account()
+  }
   @type trie_root :: MerklePatriciaTree.Trie.root_hash
   @type val :: integer()
   @type address :: <<_::160>>

--- a/lib/evm/functions.ex
+++ b/lib/evm/functions.ex
@@ -110,7 +110,7 @@ defmodule EVM.Functions do
         {:halt, :undefined_instruction}
       length(machine_state.stack) < input_count ->
         {:halt, :stack_underflow}
-      Gas.cost(state, machine_state, operation_metadata, inputs) > machine_state.gas ->
+      Gas.cost(state, machine_state, exec_env) > machine_state.gas ->
         {:halt, :out_of_gas}
       Stack.length(machine_state.stack) - input_count + output_count > @max_stack  ->
         {:halt, :stack_overflow}

--- a/lib/evm/machine_code.ex
+++ b/lib/evm/machine_code.ex
@@ -103,12 +103,12 @@ defmodule EVM.MachineCode do
   """
   @spec compile([atom() | integer()]) :: binary()
   def compile(code) do
-    for n <- code do
+    for n <- code, into: <<>> do
       case n do
         x when is_atom(x) -> EVM.Operation.encode(n)
         x when is_integer(x) -> x
-      end
-    end |> :binary.list_to_bin()
+      end |> :binary.encode_unsigned
+    end
   end
 
   @doc """

--- a/lib/evm/machine_state.ex
+++ b/lib/evm/machine_state.ex
@@ -40,13 +40,14 @@ defmodule EVM.MachineState do
 
       iex> db = MerklePatriciaTree.Test.random_ets_db()
       iex> state = MerklePatriciaTree.Trie.new(db)
-      iex> machine_state = %EVM.MachineState{gas: 10, stack: [1, 1]}
-      iex> EVM.MachineState.subtract_gas(machine_state, state, EVM.Operation.metadata(:add), %EVM.ExecEnv{})
+      iex> machine_state = %EVM.MachineState{gas: 10, stack: [1, 1], program_counter: 0}
+      iex> exec_env = %EVM.ExecEnv{machine_code: <<EVM.Operation.metadata(:add).id>>}
+      iex> EVM.MachineState.subtract_gas(machine_state, state, exec_env)
       %EVM.MachineState{gas: 7, stack: [1, 1]}
   """
-  @spec subtract_gas(MachineState.t, EVM.state, Operation.Metadata.t, list(EVM.val)) :: MachineState.t
-  def subtract_gas(machine_state, state, operation, inputs) do
-    cost = Gas.cost(state, machine_state, operation, inputs)
+  @spec subtract_gas(MachineState.t, EVM.state, ExecEnv.t) :: MachineState.t
+  def subtract_gas(machine_state, state, exec_env) do
+    cost = Gas.cost(state, machine_state, exec_env)
 
     %{machine_state| gas: machine_state.gas - cost}
   end

--- a/lib/evm/operation.ex
+++ b/lib/evm/operation.ex
@@ -31,7 +31,7 @@ defmodule EVM.Operation do
   @type opcode :: byte()
   @type stack_args :: [EVM.val]
   @type vm_map :: %{
-    optional(:state) => Trie.t,
+    optional(:state) => EVM.world_state,
     optional(:stack) => Stack.t,
     optional(:machine_state) => MachineState.t,
     optional(:sub_state) => SubState.t,
@@ -225,7 +225,7 @@ defmodule EVM.Operation do
       iex> EVM.Operation.run_operation(EVM.Operation.metadata(:log0), %{}, %EVM.MachineState{stack: [1, 2]}, %EVM.SubState{}, %EVM.ExecEnv{})
       {%{}, %EVM.MachineState{stack: []}, %EVM.SubState{}, %EVM.ExecEnv{}}
   """
-  @spec run_operation(EVM.Operation.Metadata.t, EVM.state, MachineState.t, SubState.t, ExecEnv.t) :: {EVM.state, MachineState.t, SubState.t, ExecEnv.t}
+  @spec run_operation(EVM.Operation.Metadata.t, EVM.world_state, MachineState.t, SubState.t, ExecEnv.t) :: {EVM.world_state, MachineState.t, SubState.t, ExecEnv.t}
   def run_operation(operation, state, machine_state, sub_state, exec_env) do
     {args, updated_machine_state} = operation_args(operation, state, machine_state, sub_state, exec_env)
 
@@ -335,7 +335,7 @@ defmodule EVM.Operation do
       iex> EVM.Operation.merge_state(%EVM.MachineState{program_counter: 5, stack: [4, 5]}, :add, %{}, %EVM.MachineState{}, %EVM.SubState{}, %EVM.ExecEnv{})
       {%{}, %EVM.MachineState{program_counter: 5, stack: [4, 5]}, %EVM.SubState{}, %EVM.ExecEnv{}}
   """
-  @spec merge_state(EVM.Operation.Impl.op_result, operation, EVM.state, MachineState.t, SubState.t, ExecEnv.t) :: {EVM.state, MachineState.t, SubState.t, ExecEnv.t}
+  @spec merge_state(EVM.Operation.Impl.op_result, operation, EVM.world_state, MachineState.t, SubState.t, ExecEnv.t) :: {EVM.world_state, MachineState.t, SubState.t, ExecEnv.t}
   def merge_state(:noop, _operation, state, machine_state, sub_state, exec_env) do
     {state, machine_state, sub_state, exec_env}
   end

--- a/lib/evm/operation/environmental_information.ex
+++ b/lib/evm/operation/environmental_information.ex
@@ -1,7 +1,9 @@
 defmodule EVM.Operation.EnvironmentalInformation do
   alias EVM.Operation
+  alias EVM.Stack
   alias EVM.Helpers
   alias EVM.Interface.AccountInterface
+  alias MerklePatriciaTree.Trie
 
   @doc """
   Get address of currently executing account.
@@ -26,25 +28,37 @@ defmodule EVM.Operation.EnvironmentalInformation do
       iex> account_map = %{123 => %{balance: 500}}
       iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(%{account_map: account_map})
       iex> exec_env = %EVM.ExecEnv{account_interface: account_interface}
-      iex> EVM.Operation.EnvironmentalInformation.balance([123], %{state: state, exec_env: exec_env})
-      500
+      iex> EVM.Operation.EnvironmentalInformation.balance([123], %{state: state, exec_env: exec_env, machine_state: %EVM.MachineState{}}).machine_state.stack
+      [500]
 
       iex> db = MerklePatriciaTree.Test.random_ets_db()
       iex> state = MerklePatriciaTree.Trie.new(db)
       iex> account_map = %{123 => %{balance: nil}}
       iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(%{account_map: account_map})
       iex> exec_env = %EVM.ExecEnv{account_interface: account_interface}
-      iex> EVM.Operation.EnvironmentalInformation.balance([123], %{state: state, exec_env: exec_env})
-      0
+      iex> EVM.Operation.EnvironmentalInformation.balance([123], %{state: state, exec_env: exec_env, machine_state: %EVM.MachineState{}}).machine_state.stack
+      [0]
   """
   @spec balance(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def balance([address], %{state: state, exec_env: exec_env}) do
+  def balance([address], %{state: state, exec_env: exec_env, machine_state: machine_state}) do
     wrapped_address = Helpers.wrap_address(address)
 
-    case AccountInterface.get_account_balance(exec_env.account_interface, state, wrapped_address) do
+    state = if Map.get(state, wrapped_address) do
+      state
+    else
+      Map.merge(state, %{wrapped_address => %{storage: %Trie{}}})
+    end
+
+    balance = case AccountInterface.get_account_balance(exec_env.account_interface, state, wrapped_address) do
       nil -> 0
       balance -> balance
     end
+    machine_state = %{machine_state | stack: Stack.push(machine_state.stack, balance)}
+
+    %{
+      machine_state: machine_state,
+      state: state,
+    }
   end
 
   @doc """
@@ -71,7 +85,7 @@ defmodule EVM.Operation.EnvironmentalInformation do
   ## Examples
 
       iex> exec_env = %EVM.ExecEnv{originator: <<1::160>>, sender: <<2::160>>}
-      iex> EVM.Operation.EnvironmentalInformation.caller([], %{exec_env: exec_env})
+      iex> EVM.Operation.EnvironmentalInformation.caller([], %{exec_env: exec_env, machine_state: %EVM.MachineState{}})
       <<2::160>>
   """
   @spec caller(Operation.stack_args, Operation.vm_map) :: Operation.op_result
@@ -207,20 +221,33 @@ defmodule EVM.Operation.EnvironmentalInformation do
       iex> db = MerklePatriciaTree.Test.random_ets_db()
       iex> state = MerklePatriciaTree.Trie.new(db)
       iex> exec_env = %EVM.ExecEnv{account_interface: account_interface}
-      iex> EVM.Operation.EnvironmentalInformation.extcodesize([0x01], %{exec_env: exec_env, state: state})
-      4
+      iex> EVM.Operation.EnvironmentalInformation.extcodesize([0x01], %{exec_env: exec_env, state: state, machine_state: %EVM.MachineState{}}).machine_state.stack
+      [4]
   """
   @spec extcodesize(Operation.stack_args, Operation.vm_map) :: Operation.op_result
-  def extcodesize([address], %{exec_env: exec_env, state: state}) do
+  def extcodesize([address], %{exec_env: exec_env, state: state, machine_state: machine_state}) do
     wrapped_address = Helpers.wrap_address(address)
+
+    state = if Map.get(state, wrapped_address) do
+      state
+    else
+      Map.merge(state, %{wrapped_address => %{storage: %Trie{}}})
+    end
 
     account_code = AccountInterface.get_account_code(exec_env.account_interface, state, wrapped_address)
 
-    if account_code do
+    extcodesize = if account_code do
       byte_size(account_code)
     else
       0
     end
+    machine_state = %{machine_state | stack: Stack.push(machine_state.stack, extcodesize)}
+
+    %{
+      machine_state: machine_state,
+      state: state,
+    }
+
   end
 
   @doc """
@@ -233,8 +260,8 @@ defmodule EVM.Operation.EnvironmentalInformation do
       iex> code = <<54>>
       iex> account_map = %{<<0::160>> => %{code: code}}
       iex> account_interface = EVM.Interface.Mock.MockAccountInterface.new(%{account_map: account_map})
-      iex> EVM.Operation.EnvironmentalInformation.extcodecopy([<<0::160>>, 0, 0, 1], %{exec_env: %EVM.ExecEnv{account_interface: account_interface}, machine_state: %EVM.MachineState{}, state: state})
-      %{machine_state: %EVM.MachineState{active_words: 1, gas: nil, memory: <<54>> <> <<0::248>>, program_counter: 0, previously_active_words: 0, stack: []}}
+      iex> EVM.Operation.EnvironmentalInformation.extcodecopy([<<0::160>>, 0, 0, 1], %{exec_env: %EVM.ExecEnv{account_interface: account_interface}, machine_state: %EVM.MachineState{}, state: state})[:machine_state]
+      %EVM.MachineState{active_words: 1, gas: nil, memory: <<54>> <> <<0::248>>, program_counter: 0, previously_active_words: 0, stack: []}
   """
   @spec extcodecopy(Operation.stack_args, Operation.vm_map) :: Operation.op_result
   def extcodecopy([address, code_offset, mem_offset, length], %{machine_state: machine_state, exec_env: exec_env, state: state}) do
@@ -242,13 +269,18 @@ defmodule EVM.Operation.EnvironmentalInformation do
       0
     else
       wrapped_address = Helpers.wrap_address(address)
+      state = if Map.get(state, wrapped_address) do
+        state
+      else
+        Map.merge(state, %{wrapped_address => %{storage: %Trie{}}})
+      end
 
       account_code = AccountInterface.get_account_code(exec_env.account_interface, state, wrapped_address)
 
       data = EVM.Memory.read_zeroed_memory(account_code, code_offset, length)
       machine_state = EVM.Memory.write(machine_state, mem_offset, Helpers.right_pad_bytes(data))
 
-      %{machine_state: machine_state}
+      %{machine_state: machine_state, state: state}
     end
   end
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -91,7 +91,8 @@ defmodule EVM.Helpers do
   def encode_signed(n) when n < 0, do: EVM.max_int() - abs(n)
   def encode_signed(n), do: n
 
-  @spec decode_signed(integer()) :: EVM.val
+  @spec decode_signed(integer() | nil) :: EVM.val
+  def decode_signed(n) when is_nil(n), do: 0
   def decode_signed(n) when is_integer(n) do
     decode_signed(:binary.encode_unsigned(n))
   end

--- a/test/evm/gas_test.exs
+++ b/test/evm/gas_test.exs
@@ -5,11 +5,14 @@ defmodule EVM.GasTest do
   test "Gas cost: CALL" do
     db = MerklePatriciaTree.Test.random_ets_db()
     state = MerklePatriciaTree.Trie.new(db)
-    machine_state = %EVM.MachineState{}
-    operation = EVM.Operation.metadata(:call)
     to_address = 0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6
     inputs = [3000, to_address, 0, 0, 32, 32, 32]
-    cost = EVM.Gas.cost(state, machine_state, operation, inputs)
+    machine_state = %EVM.MachineState{program_counter: 0, stack: inputs}
+    exec_env = %EVM.ExecEnv{
+      machine_code: EVM.MachineCode.compile([:call]),
+      address: to_address,
+    }
+    cost = EVM.Gas.cost(state, machine_state, exec_env)
 
     assert cost == 3046
   end

--- a/test/evm/vm_test.exs
+++ b/test/evm/vm_test.exs
@@ -4,9 +4,11 @@ defmodule EVM.VMTest do
 
   setup do
     db = MerklePatriciaTree.Test.random_ets_db(:contract_create_test)
+    address = 0x0000000000000000000000000000000000000001
+    state = %{address => %{storage: MerklePatriciaTree.Trie.new(db)}}
 
     {:ok, %{
-      state: MerklePatriciaTree.Trie.new(db)
+      state: state
     }}
   end
 
@@ -33,6 +35,7 @@ defmodule EVM.VMTest do
   end
 
   test "simple program with block storage", %{state: state} do
+    address = 0x0000000000000000000000000000000000000001
     instructions = [
       :push1,
       3,
@@ -42,14 +45,15 @@ defmodule EVM.VMTest do
       :stop
     ]
 
-    result = EVM.VM.run(state, 20006, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile(instructions)})
+    result = EVM.VM.run(state, 20006, %EVM.ExecEnv{machine_code: EVM.MachineCode.compile(instructions), address: address})
 
-    expected_state = %{state|root_hash: <<237, 28, 15, 202, 18, 122, 97, 144, 139, 12, 190, 79, 95, 4, 202, 27, 223, 19, 78, 107, 238, 238, 82, 99, 162, 126, 101, 29, 218, 189, 254, 85>>}
+    expected_account_state = %{state[address][:storage]|root_hash: <<237, 28, 15, 202, 18, 122, 97, 144, 139, 12, 190, 79, 95, 4, 202, 27, 223, 19, 78, 107, 238, 238, 82, 99, 162, 126, 101, 29, 218, 189, 254, 85>>}
+    expected_state = put_in(state, [address, :storage], expected_account_state)
 
     assert result == {expected_state, 0, %EVM.SubState{logs: "", refund: 0, suicide_list: []}, ""}
 
     {returned_state, _, _, _} = result
 
-    assert MerklePatriciaTree.Trie.Inspector.all_values(returned_state) == [{<<5::256>>, <<3::256>>}]
+    assert MerklePatriciaTree.Trie.Inspector.all_values(returned_state[address][:storage]) == [{<<5::256>>, <<3::256>>}]
   end
 end


### PR DESCRIPTION
Before we only could only store state on a single account. That would
cause suicide to wipe out all storage state. This sets up a map from
`address` => `state` for each account's state.

Other Changes:

* We had to add `exec_env` to Gas#cost parameters so we get to storage
  value of the sender when calculating an `SSTORE` cost.
* Make MachineCode#compile accept multi-byte integers