### PR TITLE
Rewrite EVM.MachineCode.decompile/1 for TCO-correctness and robustness

### DIFF
--- a/lib/evm/machine_code.ex
+++ b/lib/evm/machine_code.ex
@@ -128,6 +128,12 @@ defmodule EVM.MachineCode do
 
       iex> EVM.MachineCode.decompile(<<>>)
       []
+
+      iex> EVM.MachineCode.decompile(<<0x68, 0x00, 0x29>>)
+      [:push9, 0, 41, 0, 0, 0, 0, 0, 0, 0]
+
+      iex> EVM.MachineCode.decompile(<<0xfe, 0xf3>>, strict: false)
+      [{:unknown, 254}, :return]
   """
   @type decompile_option :: {:strict, true | false}
   @spec decompile(binary(), [decompile_option]) :: [atom() | integer()]

--- a/lib/evm/machine_code.ex
+++ b/lib/evm/machine_code.ex
@@ -140,7 +140,7 @@ defmodule EVM.MachineCode do
   end
 
   defp decompile_opcode(opcode, nil, bytecode, opts) do
-    if opts[:strict] do
+    if Keyword.get(opts, :strict, true)  do
       raise ArgumentError, "unknown opcode 0x#{Integer.to_string(opcode, 16)} encountered"
     else
       {[{:unknown, opcode}], bytecode}


### PR DESCRIPTION
Currently, `EVM.MachineCode.decompile/1` has one serious problem and one subjective problem:

* the serious problem: `decompile/1` is written to use recursive list-building, but performs operations to the result of the recursive call in a way that makes it ineligible for tail-call optimization, resulting in the ability to blow the stack with a long input.

* the subjective problem: `decompile/1` will always crash on invalid bytecode, with no option to prevent this. This makes sense when using `decompile/1` as part of a pipeline that eventually results in EVM execution, but doesn't make sense when using `decompile/1` as part of static-analysis or reverse-engineering tooling, where it is desirable to still attempt to analyze damaged or partial input data.

This PR fixes `decompile/1` to make it eligible for TCO, and also adds options that can be passed to `decompile/1` to make the decompiler more lenient in the face of bad input. The current strict behaviour is preserved as the default, so no changes to other components should need to be made.