### PR TITLE
fix duplication operations

### DIFF
--- a/lib/evm/operation/duplication.ex
+++ b/lib/evm/operation/duplication.ex
@@ -7,10 +7,12 @@ defmodule EVM.Operation.Duplication do
   ## Examples
 
       iex> EVM.Operation.Duplication.dup([1, 2, 3], %{})
-      [3, 2, 1, 1]
+      [3, 1, 2, 3]
   """
   @spec dup(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
-  def dup(list = [head | _], _) do
-    :lists.reverse([head | list])
+  def dup(list = [head | _], check) do
+    last = List.last(list)
+
+    [last | list]
   end
 end

--- a/lib/evm/operation/duplication.ex
+++ b/lib/evm/operation/duplication.ex
@@ -8,9 +8,12 @@ defmodule EVM.Operation.Duplication do
 
       iex> EVM.Operation.Duplication.dup([1, 2, 3], %{})
       [3, 1, 2, 3]
+
+      iex> EVM.Operation.Duplication.dup([1, 2, 3, 4, 5], %{})
+      [5, 1, 2, 3, 4, 5]
   """
   @spec dup(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
-  def dup(list = [head | _], check) do
+  def dup(list, _) do
     last = List.last(list)
 
     [last | list]

--- a/test/evm_test.exs
+++ b/test/evm_test.exs
@@ -34,6 +34,9 @@ defmodule EvmTest do
       :ackermann31,
       :ackermann33,
       :fibonacci16,
+      :manyFunctions100,
+      :ackermann32,
+      :fibonacci10,
 
       # :"loop-divadd-10M",
       # :"loop-exp-16b-100k",
@@ -41,15 +44,12 @@ defmodule EvmTest do
       # :"loop-exp-4b-100k",
       # :"loop-exp-nop-1M",
       # :"loop-mulmod-2M",
-      # :"ackermann32",
-      # :"fibonacci10",
       # :"loop-add-10M",
       # :"loop-divadd-unr100-10M",
       # :"loop-exp-1b-1M",
       # :"loop-exp-32b-100k",
       # :"loop-exp-8b-100k",
       # :"loop-mul",
-      # :"manyFunctions100"
     ],
     i_oand_flow_operations: :all,
     system_operations: [

--- a/test/evm_test.exs
+++ b/test/evm_test.exs
@@ -30,6 +30,27 @@ defmodule EvmTest do
       # :"201503102300PYTHON",
       # :"201503110050PYTHON",
     ],
+    performance: [
+      :ackermann31,
+      :ackermann33,
+      :fibonacci16,
+
+      # :"loop-divadd-10M",
+      # :"loop-exp-16b-100k",
+      # :"loop-exp-2b-100k",
+      # :"loop-exp-4b-100k",
+      # :"loop-exp-nop-1M",
+      # :"loop-mulmod-2M",
+      # :"ackermann32",
+      # :"fibonacci10",
+      # :"loop-add-10M",
+      # :"loop-divadd-unr100-10M",
+      # :"loop-exp-1b-1M",
+      # :"loop-exp-32b-100k",
+      # :"loop-exp-8b-100k",
+      # :"loop-mul",
+      # :"manyFunctions100"
+    ],
     i_oand_flow_operations: :all,
     system_operations: [
       :ABAcalls0,


### PR DESCRIPTION
![dup](https://i.imgur.com/DlQi8M5.png)

So `dup_n` operation copies n-th stack element to the beginning of the stack.

In our implementation we pass first n elements of stack to `dup` method. 

Expected logic:

```elixir
#dup3
iex> EVM.Operation.Duplication.dup([1, 2, 3], %{})
     [3, 1, 2, 3]
```

Current logic:

```elixir
#dup3
iex> EVM.Operation.Duplication.dup([1, 2, 3], %{})
     [3, 2, 1, 1]
```

In current implementation any `dup_n` operation where n >= 2 writes invalid data to stack.

This fix made some of vm performance tests pass. https://github.com/exthereum/evm/issues/39